### PR TITLE
di: fix optional assignment operator

### DIFF
--- a/include/di/vocab/optional/optional.h
+++ b/include/di/vocab/optional/optional.h
@@ -91,13 +91,13 @@ public:
 
     template<typename... Args>
     requires(concepts::ConstructibleFrom<T, Args...>)
-    constexpr Optional(types::InPlace, Args&&... args) {
+    constexpr explicit Optional(types::InPlace, Args&&... args) {
         emplace(util::forward<Args>(args)...);
     }
 
     template<typename U, typename... Args>
     requires(concepts::ConstructibleFrom<T, std::initializer_list<U>, Args...>)
-    constexpr Optional(types::InPlace, std::initializer_list<U> list, Args&&... args) {
+    constexpr explicit Optional(types::InPlace, std::initializer_list<U> list, Args&&... args) {
         emplace(list, util::forward<Args>(args)...);
     }
 
@@ -123,6 +123,8 @@ public:
     {
         if (other.has_value()) {
             emplace(other.value());
+        } else {
+            reset();
         }
         return *this;
     }
@@ -132,6 +134,8 @@ public:
     {
         if (other.has_value()) {
             emplace(util::move(other).value());
+        } else {
+            reset();
         }
         return *this;
     }
@@ -149,6 +153,8 @@ public:
     constexpr auto operator=(Optional<U> const& other) -> Optional& {
         if (other.has_value()) {
             emplace(other.value());
+        } else {
+            reset();
         }
         return *this;
     }
@@ -158,6 +164,8 @@ public:
     constexpr auto operator=(Optional<U>&& other) -> Optional& {
         if (other.has_value()) {
             emplace(util::move(other).value());
+        } else {
+            reset();
         }
         return *this;
     }

--- a/test/src/test_vocab_optional.cpp
+++ b/test/src/test_vocab_optional.cpp
@@ -110,6 +110,24 @@ constexpr static void trivial() {
     ASSERT(!z.has_value());
 }
 
+struct NonTrivial {
+    int x { 0 };
+
+    constexpr explicit NonTrivial(int x) : x(x) {}
+    constexpr NonTrivial(NonTrivial&& other) : x(other.x) { other.x = 0; }
+
+    constexpr ~NonTrivial() { x = 1; }
+};
+
+constexpr static void nontrivial() {
+    auto a = di::Optional<NonTrivial>();
+    a = NonTrivial(2);
+    ASSERT(a.has_value());
+
+    a = {};
+    ASSERT(!a);
+}
+
 struct M {
     constexpr M() = default;
     constexpr ~M() = default;
@@ -281,6 +299,7 @@ TESTC(vocab_optional, conversions)
 TESTC(vocab_optional, make_optional)
 TESTC(vocab_optional, references)
 TESTC(vocab_optional, trivial)
+TESTC(vocab_optional, nontrivial)
 TESTC(vocab_optional, monad)
 TESTC(vocab_optional, swap)
 TESTC(vocab_optional, compare)


### PR DESCRIPTION
# Summary

The old implementation didn't work for a basic case like `v = {}` when the optional wasn't holding a trivial type.

# Check List

- [x] Self-review the code
- [x] Update tests if necessary
- [x] Update docs if necessary
